### PR TITLE
Removed non_legacy_dai_naming because new codecs have it true by defa…

### DIFF
--- a/ac108.c
+++ b/ac108.c
@@ -1332,8 +1332,7 @@ static struct snd_soc_codec_driver ac10x_soc_codec_driver = {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
 	.idle_bias_on 	= 1,
 	.use_pmdown_time 	= 1,
-	.endianness 	= 1,
-	.non_legacy_dai_naming 	= 1,
+	.endianness 	= 1
 #endif
 };
 

--- a/seeed-voicecard.c
+++ b/seeed-voicecard.c
@@ -352,12 +352,6 @@ static int asoc_simple_init_dai_link_params(struct snd_soc_pcm_runtime *rtd)
 	struct snd_pcm_hardware hw;
 	int i, ret, stream;
 
-	/* Only codecs should have non_legacy_dai_naming set. */
-	for_each_rtd_components(rtd, i, component) {
-		if (!component->driver->non_legacy_dai_naming)
-			return 0;
-	}
-
 	/* Assumes the capabilities are the same for all supported streams */
 	for (stream = 0; stream < 2; stream++) {
 		ret = snd_soc_runtime_calc_hw(rtd, &hw, stream);

--- a/wm8960.c
+++ b/wm8960.c
@@ -1290,8 +1290,7 @@ static const struct snd_soc_codec_driver soc_codec_dev_wm8960 = {
 	#if __NO_SND_SOC_CODEC_DRV
 	.idle_bias_on		= 1,
 	.use_pmdown_time	= 1,
-	.endianness		= 1,
-	.non_legacy_dai_naming	= 1,
+	.endianness		= 1
 	#endif
 };
 


### PR DESCRIPTION
…ult. See https://patchwork.kernel.org/project/linux-amlogic/patch/20220623125250.2355471-64-ckeepax@opensource.cirrus.com/